### PR TITLE
Add support for try with syntax

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -13,6 +13,12 @@
   (pps ppx_effects)))
 
 (rule
+ (deps pp.exe)
+ (target test.actual.ml)
+ (action
+  (with-stdout-to test.actual.ml (run ./pp.exe "test.ml"))))
+
+(rule
  (alias runtest)
  (action
   (diff test.expected.ml test.actual.ml)))

--- a/test/test.expected.ml
+++ b/test/test.expected.ml
@@ -1,47 +1,65 @@
 open Obj.Effect_handlers
-
-type !_ eff += A : string -> unit eff
-
-type !_ eff += B : unit -> unit eff
-
-type !_ eff += C : string -> string eff
-
+type !_ eff +=  
+  | A: string -> unit eff 
+type !_ eff +=  
+  | B: unit -> unit eff 
+type !_ eff +=  
+  | C: string -> string eff 
 let comp on_complete =
-  perform @@ B ();
-  let c_out = perform @@ C "c_input" in
-  perform @@ A c_out;
-  on_complete ()
-
+  perform @@ (B ());
+  (let c_out = perform @@ (C "c_input") in
+   perform @@ (A c_out); on_complete ())
 let () =
   let handle_a s continue k =
-    print_endline @@ "handling a with: " ^ s;
-    continue k ()
-  in
-  let handle_b _ continue k =
-    print_endline "handling b";
-    continue k ()
-  in
+    print_endline @@ ("handling a with: " ^ s); continue k () in
+  let handle_b _ continue k = print_endline "handling b"; continue k () in
   let handle_c s continue k =
-    print_endline @@ "handling c with: " ^ s;
-    continue k "c_output"
-  in
+    print_endline @@ ("handling c with: " ^ s); continue k "c_output" in
   let on_complete () = print_endline "all_done!" in
   Obj.Effect_handlers.Deep.try_with comp on_complete
     {
-      effc =
-        (fun (type a) (e : a eff) ->
+      effc = fun (type a) ->
+        fun (e : a eff) ->
           match e with
           | A x ->
               Some
-                (fun (k : (a, _) Obj.Effect_handlers.Deep.continuation) ->
-                  handle_a x Obj.Effect_handlers.Deep.continue k)
+                ((fun (k : (a, _) Obj.Effect_handlers.Deep.continuation) ->
+                    handle_a x Obj.Effect_handlers.Deep.continue k))
           | B x ->
               Some
-                (fun (k : (a, _) Obj.Effect_handlers.Deep.continuation) ->
-                  handle_b x Obj.Effect_handlers.Deep.continue k)
+                ((fun (k : (a, _) Obj.Effect_handlers.Deep.continuation) ->
+                    handle_b x Obj.Effect_handlers.Deep.continue k))
           | C x ->
               Some
-                (fun (k : (a, _) Obj.Effect_handlers.Deep.continuation) ->
-                  handle_c x Obj.Effect_handlers.Deep.continue k)
-          | _ -> None);
+                ((fun (k : (a, _) Obj.Effect_handlers.Deep.continuation) ->
+                    handle_c x Obj.Effect_handlers.Deep.continue k))
+          | _ -> None
+    }
+let () =
+  let handle_a s k =
+    print_endline @@ ("handling a with: " ^ s);
+    Obj.Effect_handlers.Deep.continue k () in
+  let handle_b _ k =
+    print_endline "handling b"; Obj.Effect_handlers.Deep.continue k () in
+  let handle_c s k =
+    print_endline @@ ("handling c with: " ^ s);
+    Obj.Effect_handlers.Deep.continue k "c_output" in
+  let on_complete () = print_endline "all_done!" in
+  Obj.Effect_handlers.Deep.try_with (fun () -> comp on_complete) ()
+    {
+      effc = fun (type a) ->
+        function
+        | (A s : a eff) ->
+            Some
+              ((fun (k : (a, _) Obj.Effect_handlers.Deep.continuation) ->
+                  handle_a s k))
+        | (B s : a eff) ->
+            Some
+              ((fun (k : (a, _) Obj.Effect_handlers.Deep.continuation) ->
+                  handle_b s k))
+        | (C s : a eff) ->
+            Some
+              ((fun (k : (a, _) Obj.Effect_handlers.Deep.continuation) ->
+                  handle_b s k))
+        | _ -> None
     }

--- a/test/test.ml
+++ b/test/test.ml
@@ -27,3 +27,22 @@ let () =
   in
   let on_complete () = print_endline "all_done!" in
   [%with_effects comp on_complete [| A handle_a; B handle_b; C handle_c |]]
+  
+let () =
+  let handle_a s k =
+    print_endline @@ "handling a with: " ^ s;
+    Obj.Effect_handlers.Deep.continue k ()
+  in
+  let handle_b _ k =
+    print_endline "handling b";
+    Obj.Effect_handlers.Deep.continue k ()
+  in
+  let handle_c s k =
+    print_endline @@ "handling c with: " ^ s;
+    Obj.Effect_handlers.Deep.continue k "c_output"
+  in
+  let on_complete () = print_endline "all_done!" in
+  try%effect comp on_complete with
+  | A (s, k) -> handle_a s k
+  | B (s, k) -> handle_b s k
+  | C (s, k) -> handle_b s k


### PR DESCRIPTION
Add support for:
```
  try%effect comp on_complete with
  | A (s, k) -> handle_a s k
  | B (s, k) -> handle_b s k
  | C (s, k) -> handle_b s k
```